### PR TITLE
01032021001 - Correcting Foreign Keys and Seeding Integrity

### DIFF
--- a/database/migrations/2019_09_07_050834_create_attendances_table.php
+++ b/database/migrations/2019_09_07_050834_create_attendances_table.php
@@ -15,7 +15,7 @@ class CreateAttendancesTable extends Migration
     {
         Schema::create('attendances', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('user_id');
+            $table->bigInteger('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamp('start');
             $table->timestamp('end')->nullable();

--- a/database/migrations/2019_10_02_171521_create_appointments_table.php
+++ b/database/migrations/2019_10_02_171521_create_appointments_table.php
@@ -20,7 +20,7 @@ class CreateAppointmentsTable extends Migration
             $table->bigInteger('patient_id');
             $table->foreign('patient_id')->references('id')->on('patients')->onDelete('cascade');
             $table->integer('number');
-            $table->bigInteger('doctor_id')->nullable();
+            $table->bigInteger('doctor_id')->unsigned()->nullable();
             $table->char('admit',3)->default("NO");
             $table->char('completed',3)->default("NO");
             $table->foreign('doctor_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/migrations/2019_10_15_035306_create_prescriptions_table.php
+++ b/database/migrations/2019_10_15_035306_create_prescriptions_table.php
@@ -15,12 +15,12 @@ class CreatePrescriptionsTable extends Migration
     {
         Schema::create('prescriptions', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('doctor_id');
+            $table->bigInteger('doctor_id')->unsigned();
             $table->foreign('doctor_id')->references('id')->on('users')->onDelete('cascade');
             $table->bigInteger('patient_id');
             $table->foreign('patient_id')->references('id')->on('patients')->onDelete('cascade');
-            $table->bigInteger('appointment_id');
-            $table->foreign('appointment_id')->references('id')->on('patients')->onDelete('cascade');
+            $table->bigInteger('appointment_id')->unsigned();
+            $table->foreign('appointment_id')->references('id')->on('appointments')->onDelete('cascade');
             $table->char('medicine_issued',3)->default("NO");
             $table->json('bp')->nullable();
             $table->json('cholestrol')->nullable();

--- a/database/migrations/2019_12_16_105540_create_inpatients_table.php
+++ b/database/migrations/2019_12_16_105540_create_inpatients_table.php
@@ -18,13 +18,13 @@ class CreateInpatientsTable extends Migration
             $table->timestamps();
             $table->bigInteger('patient_id');
             $table->char('discharged',4)->default('NO'); // YES | NO
-            $table->bigInteger('ward_id');
+            $table->bigInteger('ward_id')->unsigned();
             $table->foreign('ward_id')->references('id')->on('wards');
             $table->date('discharged_date')->nullable();
             $table->string('description')->nullable();
             $table->string('discharged_officer')->nullable();
             $table->string('patient_inventory')->nullable();
-            
+
             // $table->string('incharge_doctor');
             $table->string('house_doctor');
             $table->string('approved_doctor');

--- a/database/migrations/2020_01_06_124452_create_medicine_prescription_table.php
+++ b/database/migrations/2020_01_06_124452_create_medicine_prescription_table.php
@@ -15,9 +15,9 @@ class CreateMedicinePrescriptionTable extends Migration
     {
         Schema::create('medicine_prescription', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('prescription_id');
+            $table->bigInteger('prescription_id')->unsigned();
             $table->foreign('prescription_id')->references('id')->on('prescriptions')->onDelete('cascade');
-            $table->bigInteger('medicine_id');
+            $table->bigInteger('medicine_id')->unsigned();
             $table->foreign('medicine_id')->references('id')->on('medicines')->onDelete('cascade');
             $table->text('note')->nullable();
             $table->string('issued')->default("NO");

--- a/database/migrations/2020_02_13_223635_clinic_patient.php
+++ b/database/migrations/2020_02_13_223635_clinic_patient.php
@@ -16,9 +16,9 @@ class ClinicPatient extends Migration
         Schema::create('clinic_patient', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('patients_id');
-            $table->bigInteger('clinic_id');
+            $table->bigInteger('clinic_id')->unsigned();
             $table->foreign('clinic_id')->references('id')->on('clinics');
-            $table->foreign('patients_id')->references('id')->on('patient');
+            $table->foreign('patients_id')->references('id')->on('patients');
             $table->timestamps();
         });
         DB::unprepared('ALTER TABLE clinic_patient ADD UNIQUE KEY(`patients_id`,`clinic_id`)');

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,10 +11,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call(AttendancesTableSeeder::class);
         $this->call(UsersTableSeeder::class);
-        $this->call(MedicinesTableSeeder::class);
         $this->call(PatientTableSeeder::class);
+        $this->call(AttendancesTableSeeder::class);
+        $this->call(MedicinesTableSeeder::class);
         $this->call(WardTableSeeder::class);
         $this->call(ClinicsTableSeeder::class);
         $this->call(NoticeboardsTableSeeder::class);


### PR DESCRIPTION
Updated the migrations so they can run without integrity constraints problems in MySQL with the new updates and corrections from Laravel.

For Instance, what I did:
* Change the ForeignKey column field to ```->unsigned()``` where the ```Id``` key attributes has ```BigIncrements```. Ex: **doctor_id** in _prescriptions_ table with the **id** of the _users_ table.
* Changed the order of the migrations: First **appointments** and then **prescriptions**.
* Changed the order of the Seeding: Refer to **DatabaseSeeder.php** file.